### PR TITLE
feat: add getDurationInSeconds method to Execution entity for calcula…

### DIFF
--- a/src/modules/workout/domain/entities/execution/execution.entity.ts
+++ b/src/modules/workout/domain/entities/execution/execution.entity.ts
@@ -93,6 +93,13 @@ export class Execution {
     this._repetitionAmount = amount;
   }
 
+  public getDurationInSeconds(): number {
+    if (!this._startedAt) throw new Error('Execução não foi iniciada');
+    const endTime = this._completedAt || new Date();
+    const durationMs = endTime.getTime() - this._startedAt.getTime();
+    return Math.floor(durationMs / 1000);
+  }  
+
   public toObject() {
     return {
       id: this._id.value,


### PR DESCRIPTION
This pull request introduces a new method to the `Execution` class in the `src/modules/workout/domain/entities/execution/execution.entity.ts` file. The method calculates the duration of an execution in seconds.

Key change:

* Added the `getDurationInSeconds` method to the `Execution` class. This method calculates the duration of an execution in seconds by subtracting the start time (`_startedAt`) from the end time (`_completedAt` or the current time if not completed). It throws an error if the execution has not been started.